### PR TITLE
[FIX] account_statement_import_online[_ponto] : avoid losing context …

### DIFF
--- a/account_statement_import_online/models/online_bank_statement_provider.py
+++ b/account_statement_import_online/models/online_bank_statement_provider.py
@@ -368,7 +368,7 @@ class OnlineBankStatementProvider(models.Model):
             else (self.next_run - self._get_next_run_period())
         )
         date_until = self.next_run
-        self._pull(date_since, date_until)
+        self.with_context(scheduled=True)._pull(date_since, date_until)
 
     @api.model
     def _scheduled_pull(self):
@@ -382,7 +382,7 @@ class OnlineBankStatementProvider(models.Model):
                 "Pulling online bank statements of: %s"
                 % ", ".join(providers.mapped("journal_id.name"))
             )
-            for provider in providers.with_context(scheduled=True):
+            for provider in providers:
                 provider.with_delay()._pull_with_job()
         _logger.info("Scheduled pull of online bank statements complete.")
 

--- a/account_statement_import_online/static/description/index.html
+++ b/account_statement_import_online/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -458,7 +458,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
+++ b/account_statement_import_online_ponto/models/online_bank_statement_provider_ponto.py
@@ -80,10 +80,12 @@ class OnlineBankStatementProvider(models.Model):
         if not lines:
             _logger.info(_("No lines were retrieved from Ponto"))
         else:
+            last_identifier = lines[0].get("id")
+            self._ponto_store_lines(lines)
             # For scheduled runs, store latest identifier.
             if is_scheduled:
-                self.ponto_last_identifier = lines[0].get("id")
-            self._ponto_store_lines(lines)
+                self.ponto_last_identifier = last_identifier
+                self._schedule_next_run()
 
     def _ponto_retrieve_data(self, date_since, date_until):
         """Fill buffer with data from Ponto.


### PR DESCRIPTION
…when using with_delay + update ponto last successful run

Before using jobs, Ponto providers were not updating the "last_successful_run" field.
This was not visible because transactions in schedule mode are retrieved until the ponto_last_identifier is found.
So date_until is not relevant when calling _ponto_data_retrieve in schedule mode.

But now that we use jobs, as with_delay is not propagating context, is_scheduled was False in jobs.

So transactions were retrieved until the "last succesful run" date.
Statements were created or updated at every run but as transactions were already imported, there were filtered out, so that empty statements appeared even if not allowed by configuration